### PR TITLE
[feat/#1] MongoDB 데이터를 MySQL 테이블에 bulk insert 배치 구현

### DIFF
--- a/src/main/java/com/techeer/checkitbatch/batch/CustomMongoItemReader.java
+++ b/src/main/java/com/techeer/checkitbatch/batch/CustomMongoItemReader.java
@@ -1,0 +1,33 @@
+package com.techeer.checkitbatch.batch;
+
+import com.techeer.checkitbatch.domain.book.entity.Book;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.data.MongoItemReader;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class CustomMongoItemReader<T> extends MongoItemReader<T> {
+
+    public CustomMongoItemReader(MongoOperations template, String collection, Class<? extends T> targetType) {
+        super();
+        this.setTemplate(template);
+        this.setCollection(collection);
+        this.setTargetType(targetType);
+    }
+
+    @Override
+    public T read() throws Exception {
+        T item = super.read();
+        if (item != null) {
+            Book book = (Book) item;
+            log.info("******************Reading Title: {}******************", book.getTitle());
+        }
+        return item;
+    }
+}
+

--- a/src/main/java/com/techeer/checkitbatch/batch/DatabaseConfig.java
+++ b/src/main/java/com/techeer/checkitbatch/batch/DatabaseConfig.java
@@ -1,6 +1,7 @@
 package com.techeer.checkitbatch.batch;
 
 import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.batch.BatchDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -33,6 +34,7 @@ public class DatabaseConfig {
     }
 
     @Bean
+    @Qualifier("mysqlDataSource")
     @BatchDataSource
     @ConfigurationProperties("spring.datasource-mysql")
     DataSource mysqlDb(){
@@ -40,7 +42,4 @@ public class DatabaseConfig {
         builder.type(HikariDataSource.class);
         return builder.build();
     }
-
-
-
 }


### PR DESCRIPTION
## 📢 기능 설명 
- MongoDB newBook 컬렉션 데이터를 MySQL books 테이블에 저장
<img width="232" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/batch/assets/101381901/410a718c-8509-4e9b-ac4d-57c4d9841a5a">

- CustomMongoItemReader 클래스 생성하여 Reader로 읽고 있는 데이터 로그 출력
- DataSource 빈이 h2, mysql 2개라서 h2를 가져오는 오류 발생 -> `@Qualifier`로 명시하여 해결
<br>

## 연결된 issue
close #1
<br>
<br>


## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 